### PR TITLE
Sense about contest from execution directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 
+
 # Test binary, built with `go test -c`
 *.test
 
@@ -12,4 +13,5 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
+mango

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.2.1
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/shirou/gopsutil v3.21.4+incompatible
+	github.com/smartystreets/goconvey v1.6.4
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,7 @@ github.com/jedib0t/go-pretty/v6 v6.2.1/go.mod h1:+nE9fyyHGil+PuISTCrp7avEdo6bqoM
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213 h1:qGQQKEcAR99REcMpsXCp3lJ03zYT1PkRd3kQGPn9GVg=
@@ -163,7 +164,9 @@ github.com/shirou/gopsutil v3.21.4+incompatible h1:fuHcTm5mX+wzo542cmYcV9RTGQLbn
 github.com/shirou/gopsutil v3.21.4+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/src/cmd/compile.go
+++ b/src/cmd/compile.go
@@ -4,6 +4,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/k0kubun/go-ansi"
 	"github.com/skmonir/mango/src/config"
+	"github.com/skmonir/mango/src/intel"
 	"github.com/skmonir/mango/src/system"
 	"github.com/spf13/cobra"
 )
@@ -25,7 +26,9 @@ var compileCmd = &cobra.Command{
 			}
 			if cfg.Workspace == "" {
 				ansi.Println(color.RedString("workspace directory path missing. run 'mango configure' to set workspace"))
-				return
+				if !intel.GuessWorkspace(&cfg) {
+					return
+				}
 			}
 			if err := system.Compile(cfg, args[0]); err != nil {
 				ansi.Println(color.RedString(err.Error()))

--- a/src/cmd/parse.go
+++ b/src/cmd/parse.go
@@ -4,6 +4,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/k0kubun/go-ansi"
 	"github.com/skmonir/mango/src/config"
+	"github.com/skmonir/mango/src/intel"
 	"github.com/skmonir/mango/src/system"
 	"github.com/spf13/cobra"
 )
@@ -13,6 +14,20 @@ var parseCmd = &cobra.Command{
 	Short: "Parses a contest/problem",
 	Run: func(cmd *cobra.Command, args []string) {
 		argc := len(args)
+
+		if argc == 0 {
+			cfg, err := config.GetConfig()
+			if err != nil {
+				ansi.Println(color.RedString(err.Error()))
+				return
+			}
+			if intel.GuessWorkspace(&cfg) {
+				if err := system.Parse(cfg, cfg.CurrentContestId); err == nil {
+					return
+				}
+			}
+		}
+
 		if argc < 1 {
 			ansi.Println(color.RedString("too few argument for 'parse' command"))
 		} else if argc > 1 {
@@ -25,7 +40,9 @@ var parseCmd = &cobra.Command{
 			}
 			if cfg.Workspace == "" {
 				ansi.Println(color.RedString("workspace directory path missing. run 'mango configure' to set workspace"))
-				return
+				if !intel.GuessWorkspace(&cfg) {
+					return
+				}
 			}
 			if err := system.Parse(cfg, args[0]); err != nil {
 				ansi.Println(color.RedString(err.Error()))

--- a/src/cmd/test.go
+++ b/src/cmd/test.go
@@ -25,7 +25,7 @@ var testCmd = &cobra.Command{
 			}
 			if cfg.Workspace == "" {
 				ansi.Println(color.RedString("workspace directory path missing. run 'mango configure' to set workspace"))
-				return
+				ansi.Println(color.WhiteString("guessing workspace, platform and contestID from current directory"))
 			}
 			if err := system.RunTest(cfg, args[0]); err != nil {
 				ansi.Println(color.RedString(err.Error()))

--- a/src/cmd/test.go
+++ b/src/cmd/test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/k0kubun/go-ansi"
 	"github.com/skmonir/mango/src/config"
+	"github.com/skmonir/mango/src/intel"
 	"github.com/skmonir/mango/src/system"
 	"github.com/spf13/cobra"
 )
@@ -25,7 +26,9 @@ var testCmd = &cobra.Command{
 			}
 			if cfg.Workspace == "" {
 				ansi.Println(color.RedString("workspace directory path missing. run 'mango configure' to set workspace"))
-				ansi.Println(color.WhiteString("guessing workspace, platform and contestID from current directory"))
+				if !intel.GuessWorkspace(&cfg) {
+					return
+				}
 			}
 			if err := system.RunTest(cfg, args[0]); err != nil {
 				ansi.Println(color.RedString(err.Error()))

--- a/src/config/configService.go
+++ b/src/config/configService.go
@@ -139,6 +139,8 @@ func CreateDefaultConfig() error {
 		CompilationArgs:    "-std=c++17",
 		OJ:                 "codeforces",
 		Host:               "https://codeforces.com",
+		SrcDir:             "src",
+		TestDir:            "testcase",
 	}
 
 	if err := SaveConfig(cfg); err != nil {

--- a/src/config/configuration.go
+++ b/src/config/configuration.go
@@ -9,4 +9,6 @@ type Configuration struct {
 	Host               string
 	TemplatePath       string
 	Author             string
+	SrcDir             string
+	TestDir            string
 }

--- a/src/enums/language.go/lang.go
+++ b/src/enums/language.go/lang.go
@@ -1,0 +1,51 @@
+package language
+
+type Language int
+
+func (l Language) Name() string {
+	return names[l]
+}
+
+func (l Language) CompileCmd(srcPath, binPath string) string {
+	return compileCmd[CPP](srcPath, binPath)
+}
+
+const (
+	CPP Language = iota
+	CPP11
+	CPP14
+	CPP17
+	GO
+	UKN
+)
+
+const Default = CPP17
+
+var names = map[Language]string{
+	CPP:   "C++",
+	CPP11: "C++11",
+	CPP14: "C++14",
+	CPP17: "C++17",
+	GO:    "go",
+	UKN:   "uknown",
+}
+
+var compileCmd = map[Language]func(src, bin string) string{
+	CPP:   func(src, bin string) string { return "g++ " + src + " -o " + bin },
+	CPP11: func(src, bin string) string { return "g++ -std=c++11 " + src + " -o " + bin },
+	CPP14: func(src, bin string) string { return "g++ -std=c++14 " + src + " -o " + bin },
+	CPP17: func(src, bin string) string { return "g++ -std=c++17 " + src + " -o " + bin },
+	GO:    func(src, bin string) string { return "go build -o " + bin + " " + src },
+	UKN:   func(src, bin string) string { return "" },
+}
+
+func FindLangFromExt(ext string) Language {
+	L := UKN
+	switch ext {
+	case "cpp":
+		L = CPP17
+	case "go":
+		L = GO
+	}
+	return L
+}

--- a/src/enums/oj/oj.go
+++ b/src/enums/oj/oj.go
@@ -1,0 +1,11 @@
+package oj
+
+type OJ string
+
+func (o OJ) String() string {
+	return string(o)
+}
+
+const (
+	CF OJ = "codeforces"
+)

--- a/src/intel/intel.go
+++ b/src/intel/intel.go
@@ -1,0 +1,32 @@
+package intel
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/skmonir/mango/src/config"
+)
+
+func WhereAmI() (*config.Configuration, error) {
+	dir, err := os.Getwd()
+	return whereAmI(dir), err
+}
+
+func whereAmI(dir string) *config.Configuration {
+	cfg := &config.Configuration{}
+	part := ""
+
+	for dir != "" {
+		fmt.Println(dir)
+		dir, part = path.Split(strings.TrimRight(dir, "/"))
+		if _, err := strconv.ParseInt(part, 10, 32); err == nil {
+			cfg.CurrentContestId = part
+		} else if strings.ToLower(part) == "cf" || strings.ToLower(part) == "codeforces" {
+			cfg.OJ = "codeforces"
+		}
+	}
+	return cfg
+}

--- a/src/intel/intel.go
+++ b/src/intel/intel.go
@@ -6,8 +6,26 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fatih/color"
+	"github.com/k0kubun/go-ansi"
 	"github.com/skmonir/mango/src/config"
 )
+
+func GuessWorkspace(cfg *config.Configuration) bool {
+	ansi.Println(color.RedString("workspace directory path missing. run 'mango configure' to set workspace"))
+
+	guessed := WhereAmI()
+	if guessed == nil {
+		ansi.Println(color.RedString("couldn't guess workspace"))
+		return false
+	}
+	ansi.Println(color.WhiteString("guessing workspace"))
+	cfg.Workspace = guessed.Workspace
+	cfg.CurrentContestId = guessed.CurrentContestId
+	cfg.OJ = guessed.OJ
+	ansi.Println(color.GreenString("guessed! Workspace:%s, OJ:%s, Contest:%s", cfg.Workspace, cfg.OJ, cfg.CurrentContestId))
+	return true
+}
 
 func WhereAmI() *config.Configuration {
 	dir, err := os.Getwd()

--- a/src/intel/intel.go
+++ b/src/intel/intel.go
@@ -1,7 +1,6 @@
 package intel
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"strconv"
@@ -10,23 +9,35 @@ import (
 	"github.com/skmonir/mango/src/config"
 )
 
-func WhereAmI() (*config.Configuration, error) {
+func WhereAmI() *config.Configuration {
 	dir, err := os.Getwd()
-	return whereAmI(dir), err
+	if err != nil {
+		return nil
+	}
+	return whereAmI(dir)
 }
 
 func whereAmI(dir string) *config.Configuration {
 	cfg := &config.Configuration{}
 	part := ""
 
+	conId, ojName := false, false
 	for dir != "" {
-		fmt.Println(dir)
 		dir, part = path.Split(strings.TrimRight(dir, "/"))
 		if _, err := strconv.ParseInt(part, 10, 32); err == nil {
 			cfg.CurrentContestId = part
+			conId = true
 		} else if strings.ToLower(part) == "cf" || strings.ToLower(part) == "codeforces" {
 			cfg.OJ = "codeforces"
+			ojName = true
 		}
+		if conId && ojName {
+			cfg.Workspace = dir
+			return cfg
+		}
+	}
+	if !conId || !ojName || cfg.Workspace == "" {
+		return nil
 	}
 	return cfg
 }

--- a/src/intel/intel_test.go
+++ b/src/intel/intel_test.go
@@ -15,6 +15,20 @@ func Test_whereAmI(t *testing.T) {
 			So(c.OJ, ShouldEqual, "codeforces")
 			So(c.CurrentContestId, ShouldEqual, "1545")
 		})
+		Convey("valid-2", func() {
+			p := "/cf/src/1545"
+			c := whereAmI(p)
+			So(c, ShouldNotBeNil)
+			So(c.OJ, ShouldEqual, "codeforces")
+			So(c.CurrentContestId, ShouldEqual, "1545")
+		})
+		Convey("invalid", func() {
+			p := "/uva/src/problem-1245"
+			c := whereAmI(p)
+			So(c, ShouldNotBeNil)
+			So(c.OJ, ShouldNotEqual, "codeforces")
+			So(c.CurrentContestId, ShouldNotEqual, "1545")
+		})
 	})
 
 }

--- a/src/intel/intel_test.go
+++ b/src/intel/intel_test.go
@@ -9,25 +9,25 @@ import (
 func Test_whereAmI(t *testing.T) {
 	Convey("Test_whereAmI", t, func() {
 		Convey("valid", func() {
-			p := "/codeforces/src/1545"
+			p := "/codeforces/1545"
 			c := whereAmI(p)
 			So(c, ShouldNotBeNil)
+			So(c.Workspace, ShouldEqual, "/")
 			So(c.OJ, ShouldEqual, "codeforces")
 			So(c.CurrentContestId, ShouldEqual, "1545")
 		})
 		Convey("valid-2", func() {
-			p := "/cf/src/1545"
+			p := "/some/random/dir/cf/src/1545"
 			c := whereAmI(p)
 			So(c, ShouldNotBeNil)
+			So(c.Workspace, ShouldEqual, "/some/random/dir/")
 			So(c.OJ, ShouldEqual, "codeforces")
 			So(c.CurrentContestId, ShouldEqual, "1545")
 		})
 		Convey("invalid", func() {
 			p := "/uva/src/problem-1245"
 			c := whereAmI(p)
-			So(c, ShouldNotBeNil)
-			So(c.OJ, ShouldNotEqual, "codeforces")
-			So(c.CurrentContestId, ShouldNotEqual, "1545")
+			So(c, ShouldBeNil)
 		})
 	})
 

--- a/src/intel/intel_test.go
+++ b/src/intel/intel_test.go
@@ -1,0 +1,20 @@
+package intel
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func Test_whereAmI(t *testing.T) {
+	Convey("Test_whereAmI", t, func() {
+		Convey("valid", func() {
+			p := "/codeforces/src/1545"
+			c := whereAmI(p)
+			So(c, ShouldNotBeNil)
+			So(c.OJ, ShouldEqual, "codeforces")
+			So(c.CurrentContestId, ShouldEqual, "1545")
+		})
+	})
+
+}

--- a/src/system/compile.go
+++ b/src/system/compile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/skmonir/mango/src/config"
 	"github.com/skmonir/mango/src/utils"
@@ -15,7 +16,9 @@ func getCompilationCommand(cfg config.Configuration, problemId string) (string, 
 	filePathWithoutExt := utils.GetSourceFilePathWithoutExt(cfg, problemId)
 
 	if !utils.IsFileExist(filePathWithExt) {
-		return "", errors.New("source file not found")
+		if filePathWithExt = utils.GetSourceFilePathWithExt(cfg, strings.ToLower(problemId)); !utils.IsFileExist(filePathWithExt) {
+			return "", errors.New("source file not found")
+		}
 	}
 
 	command := fmt.Sprintf("%v %v %v -o %v", cfg.CompilationCommand, cfg.CompilationArgs, filePathWithExt, filePathWithoutExt)

--- a/src/system/test.go
+++ b/src/system/test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/k0kubun/go-ansi"
 	"github.com/skmonir/mango/src/config"
 	"github.com/skmonir/mango/src/dto"
+	"github.com/skmonir/mango/src/intel"
 	"github.com/skmonir/mango/src/utils"
 )
 
@@ -77,6 +78,15 @@ func RunTest(cfg config.Configuration, cmd string) error {
 	if contestId != "" {
 		cfg.CurrentContestId = contestId
 	}
+	if wCfg := intel.WhereAmI(); cfg.CurrentContestId == "" && wCfg != nil {
+		cfg.Workspace = wCfg.Workspace
+		cfg.CurrentContestId = wCfg.CurrentContestId
+		cfg.OJ = wCfg.OJ
+
+		ansi.Println(color.WhiteString("guessed! Workspace:%s, OJ:%s, Contest:%s", cfg.Workspace, cfg.OJ, cfg.CurrentContestId))
+
+	}
+
 	if cfg.CurrentContestId == "" {
 		return errors.New("please set current contest id or use contest & problem id combination like 1512G")
 	}

--- a/src/system/test.go
+++ b/src/system/test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/k0kubun/go-ansi"
 	"github.com/skmonir/mango/src/config"
 	"github.com/skmonir/mango/src/dto"
-	"github.com/skmonir/mango/src/intel"
 	"github.com/skmonir/mango/src/utils"
 )
 
@@ -77,14 +76,6 @@ func RunTest(cfg config.Configuration, cmd string) error {
 	}
 	if contestId != "" {
 		cfg.CurrentContestId = contestId
-	}
-	if wCfg := intel.WhereAmI(); cfg.CurrentContestId == "" && wCfg != nil {
-		cfg.Workspace = wCfg.Workspace
-		cfg.CurrentContestId = wCfg.CurrentContestId
-		cfg.OJ = wCfg.OJ
-
-		ansi.Println(color.WhiteString("guessed! Workspace:%s, OJ:%s, Contest:%s", cfg.Workspace, cfg.OJ, cfg.CurrentContestId))
-
 	}
 
 	if cfg.CurrentContestId == "" {

--- a/src/utils/pathUtils.go
+++ b/src/utils/pathUtils.go
@@ -7,7 +7,7 @@ import (
 )
 
 func GetSourceDirPath(cfg config.Configuration) string {
-	return filepath.Join(cfg.Workspace, cfg.OJ, cfg.CurrentContestId, "src")
+	return filepath.Join(cfg.Workspace, cfg.OJ, cfg.CurrentContestId, cfg.SrcDir)
 }
 
 func GetSourceFilePathWithExt(cfg config.Configuration, problemId string) string {
@@ -19,7 +19,7 @@ func GetSourceFilePathWithoutExt(cfg config.Configuration, problemId string) str
 }
 
 func GetTestcaseDirPath(cfg config.Configuration) string {
-	return filepath.Join(cfg.Workspace, cfg.OJ, cfg.CurrentContestId, "testcase")
+	return filepath.Join(cfg.Workspace, cfg.OJ, cfg.CurrentContestId, cfg.TestDir)
 }
 
 func GetTestcaseFilePath(cfg config.Configuration, problemId string) string {


### PR DESCRIPTION
just move to any contest directory and issue following command 
- "mango test A" to test the solution to the specific contest
- "mango parse" will parse all problem of current contest if your execution path have a contestID in it.
- added src/test directory in configuration.
- also added a few package to support multi lang/OJ. you may make use of the package to integrate other language or OJ
